### PR TITLE
Round GSU HPA workspaces sizes to a granularity, to reduce solution cache fragmentation

### DIFF
--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -506,9 +506,13 @@ namespace Tensile
             return getOperationDescription();
         }
 
+        static constexpr size_t HPA_GSU_WORKSPACE_SIZE_GRANULARITY = 256;
+
         void setWorkspaceSize(size_t size)
         {
-            m_workspaceSize = size;
+            m_workspaceSize = ~size ? (size / HPA_GSU_WORKSPACE_SIZE_GRANULARITY)
+                                          * HPA_GSU_WORKSPACE_SIZE_GRANULARITY
+                                    : size;
         }
 
         size_t workspaceSize() const
@@ -565,7 +569,7 @@ namespace Tensile
         size_t m_allocatedElementsNonBatchA;
         size_t m_allocatedElementsNonBatchB;
 
-        size_t m_workspaceSize;
+        size_t m_workspaceSize = 0;
 
         void normalize();
         void consistencyCheck() const;

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -536,8 +536,8 @@ namespace Tensile
         , m_batchIndices(batchIndices)
         , m_boundIndices(boundIndices)
         , m_beta(beta)
-        , m_workspaceSize(workspaceSize)
     {
+        setWorkspaceSize(workspaceSize);
         consistencyCheck();
         normalize();
     }

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -851,13 +851,18 @@ namespace Tensile
         return spm;
     }
 
+    static constexpr auto HPA_GSU_WORKSPACE_SIZE_GRANULARITY
+        = Tensile::ContractionProblem::HPA_GSU_WORKSPACE_SIZE_GRANULARITY;
+
     size_t ContractionSolution::requiredWorkspaceSize(Problem const& problem) const
     {
         size_t size = 0;
 
         size += problem.d().totalAllocatedElements() * sizeMapping.workspaceSizePerElemC;
 
-        return size;
+        return ((size + HPA_GSU_WORKSPACE_SIZE_GRANULARITY - 1)
+                / HPA_GSU_WORKSPACE_SIZE_GRANULARITY)
+               * HPA_GSU_WORKSPACE_SIZE_GRANULARITY;
     }
 
     ContractionSolution::ProjectedPerformance


### PR DESCRIPTION
To reduce fragmentation of GSU workspace sizes in the solution cache, they are rounded down to the nearest multiple of `HPA_GSU_WORKSPACE_SIZE_GRANULARITY` when they are supplied by the user, and they are rounded up to the nearest multiple of `HPA_GSU_WORKSPACE_SIZE_GRANULARITY` when they are returned from the found solution as the optimal workspace size.

This way, the workspace size is rounded down when supplied as a limit to workspace size, so that _at most_ the supplied value is used, and is rounded up when it is returned as an optimal workspace size, so that _at least_ the supplied value is returned, while keeping it a multiple of `HPA_GSU_WORKSPACE_SIZE_GRANULARITY`, to reduce fragmentation.

This increases the chances that a solution already cached will be found in the cache, instead of looking for a solution with a very specific workspace size which isn't in the cache. All workspace sizes within the granularity will be considered the same, and will be cached the same.

When `~workspace_size == 0` (i.e., `workspace_size == ~size_t(0)`), the maximum possible workspace size, is set by the user, it stays unchanged at `~size_t(0)`.

Right now `256` is the value used for `HPA_GSU_WORKSPACE_SIZE_GRANULARITY`, but it can be changed. It is desired that it be large enough to avoid fragmentation, but that it is small enough to express different workspace sizes needed.
